### PR TITLE
Motoko Canister Error Handling Improvements

### DIFF
--- a/examples/common/candid.did
+++ b/examples/common/candid.did
@@ -20,6 +20,18 @@ type Utxo = record {
   confirmations: nat32;
 };
 
+type BuildTransactionError = variant {
+  MalformedDestinationAddress;
+  InsufficientBalance;
+  MalformedSourceAddress;
+};
+
+type SignTransactionError = variant {
+  MalformedSourceAddress;
+  MalformedTransaction;
+  InvalidPrivateKeyWif;
+};
+
 service: {
   // Given the private key, compute the P2PKH address.
   get_p2pkh_address: (private_key_wif: text, Network) -> (text) query;
@@ -30,13 +42,19 @@ service: {
     destination_address: text,
     amount: Satoshi,
     fees: Satoshi
-  ) -> (blob, vec nat64) query;
+  ) -> (variant {
+    Ok : record { blob; vec nat64 };
+    Err : BuildTransactionError;
+  }) query;
 
   // Creates a signed Bitcoin transaction from a previously built transaction.
   sign_transaction: (
     private_key_wif: text,
     serialized_transaction: blob,
     source_address: text
-  ) -> (blob) query;
+  ) -> (variant {
+    Ok : blob;
+    Err: SignTransactionError
+  }) query;
 
 }

--- a/examples/common/src/lib.rs
+++ b/examples/common/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod types;
+
 use bitcoin::{
     blockdata::script::Builder,
     hashes::Hash,
@@ -123,4 +125,3 @@ pub fn sign_transaction(
 
     transaction
 }
-

--- a/examples/common/src/main.rs
+++ b/examples/common/src/main.rs
@@ -40,7 +40,10 @@ fn get_p2pkh_address(private_key_wif: String, network: NetworkCandid) -> String 
     example_common::get_p2pkh_address(&private_key, network).to_string()
 }
 
-fn build_transaction_(
+// Returns the transaction as serialized bytes and the UTXO indices used for the transaction.
+#[query]
+#[candid_method(query)]
+fn build_transaction(
     utxos: Vec<Utxo>,
     source_address: String,
     destination_address: String,
@@ -79,20 +82,9 @@ fn build_transaction_(
     Ok((tx.serialize(), used_utxo_indices))
 }
 
-// Returns the transaction as serialized bytes and the UTXO indices used for the transaction.
 #[query]
 #[candid_method(query)]
-fn build_transaction(
-    utxos: Vec<Utxo>,
-    source_address: String,
-    destination_address: String,
-    amount: u64,
-    fees: u64,
-) -> Result<(Vec<u8>, Vec<usize>), BuildTransactionError> {
-    build_transaction_(utxos, source_address, destination_address, amount, fees)
-}
-
-fn sign_transaction_(
+fn sign_transaction(
     private_key_wif: String,
     serialized_transaction: Vec<u8>,
     source_address: String,
@@ -104,16 +96,6 @@ fn sign_transaction_(
     let tx: Transaction = deserialize(serialized_transaction.as_slice())
         .map_err(|_| SignTransactionError::MalformedTransaction)?;
     Ok(example_common::sign_transaction(tx, private_key, source_address).serialize())
-}
-
-#[query]
-#[candid_method(query)]
-fn sign_transaction(
-    private_key_wif: String,
-    serialized_transaction: Vec<u8>,
-    source_address: String,
-) -> Result<Vec<u8>, SignTransactionError> {
-    sign_transaction_(private_key_wif, serialized_transaction, source_address)
 }
 
 fn main() {}

--- a/examples/common/src/types.rs
+++ b/examples/common/src/types.rs
@@ -1,0 +1,15 @@
+use ic_cdk::export::candid::{CandidType, Deserialize};
+
+#[derive(CandidType, Deserialize)]
+pub enum BuildTransactionError {
+    InsufficientBalance,
+    MalformedDestinationAddress,
+    MalformedSourceAddress,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum SignTransactionError {
+    InvalidPrivateKeyWif,
+    MalformedSourceAddress,
+    MalformedTransaction,
+}

--- a/examples/motoko/src/Types.mo
+++ b/examples/motoko/src/Types.mo
@@ -8,9 +8,11 @@ module Types {
     };
 
     public type SendError = {
-        #MalformedAddress;
+        #MalformedSourceAddress;
+        #MalformedDestinationAddress;
         #MalformedTransaction;
         #InsufficientBalance;
+        #InvalidPrivateKeyWif;
         #Unknown;
     };
 


### PR DESCRIPTION
This PR adds error responses for the common canister used by the Motoko example project.

It adds the following errors to the `SendError` type:

```motoko
#MalformedSourceAddress;
#MalformedDestinationAddress;
#MalformedTransaction;
#InvalidPrivateKeyWif;
```

All `expect`s have been replaced with a designated variant arm.