### PR TITLE
chore: Switch copyright to DFINITY Stiftung

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 DFINITY LLC.
+   Copyright 2022 DFINITY Stiftung.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
IP needs to be owned by the parent entity, i.e. DFINITY Stiftung, and not by the subsidiary (DFINITY LLC).